### PR TITLE
Update code-test.yml: change schedule to manual trigger for periodic testing of Verse.db

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -1,9 +1,6 @@
 name: Periodic testing of the Verse.db
 
 on:
-  schedule:
-    - cron: "0 * * * *"
-  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
- The schedule trigger in the code-test.yml workflow has been removed.
- The workflow will now only run